### PR TITLE
fix: MygrationPage DuesModal onClose/onConfirm 콜백 호출 누락 수정

### DIFF
--- a/src/pages/MygrationPage.tsx
+++ b/src/pages/MygrationPage.tsx
@@ -126,8 +126,8 @@ export default function MygrationPage() {
     <DuesModal
       isNew={false}
       isOpen={onModal}
-      onClose={() => setOnModal}
-      onConfirm={() => setOnModal}
+      onClose={() => setOnModal(false)}
+      onConfirm={() => setOnModal(false)}
     />
   ) : (
     <div className="flex h-full h-screen w-full flex-col items-center bg-black">


### PR DESCRIPTION
## Summary
- MygrationPage에서 DuesModal의 `onClose`/`onConfirm` 콜백이 `setOnModal`을 호출하지 않고 함수 참조만 반환하여 모달을 닫을 수 없는 버그를 수정합니다.

## Problem
```tsx
// Before — setOnModal 함수 참조만 반환, 호출하지 않음
onClose={() => setOnModal}
onConfirm={() => setOnModal}
```
이로 인해 마이그레이션 성공 후 학회비 미납(LOGIN_BLOCKED) 상태에서 DuesModal이 열리면, X 버튼이나 확인 버튼을 눌러도 모달이 닫히지 않습니다.

## Changes
```tsx
// After — setOnModal(false) 호출로 모달 정상 닫힘
onClose={() => setOnModal(false)}
onConfirm={() => setOnModal(false)}
```

다른 DuesModal 사용처(SignupPage, Hero, MobileHero)는 모두 정상 동작 확인 완료.

## Test plan
- [ ] 마이그레이션 후 학회비 미납(LOGIN_BLOCKED) 시 DuesModal 표시 확인
- [ ] DuesModal에서 X 버튼 클릭 시 모달 닫힘 확인
- [ ] DuesModal에서 확인 버튼 클릭 시 모달 닫힘 확인