### PR TITLE
fix: Layout에서 Footer 이중 렌더링 제거

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -18,7 +18,6 @@ export default function Layout() {
         <Outlet />
       </main>
       {!isLoginPage && <Footer />}
-      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Layout 컴포넌트에서 `<Footer />`가 2번 렌더링되는 버그를 수정합니다.

## Problem
```tsx
// Before — Footer가 항상 2번 렌더링됨
{!isLoginPage && <Footer />}
<Footer />                    // ← 무조건 렌더링되는 중복
```
로그인 페이지가 아닌 경우 Footer 2개, 로그인 페이지에서도 Footer 1개가 렌더링됩니다.
현재 Footer가 `hidden`이라 시각적 문제는 없지만, Footer 구현 시 즉시 이중 렌더링 문제가 발생합니다.

## Changes
```tsx
// After — 중복 제거
{!isLoginPage && <Footer />}
```

## Test plan
- [ ] 메인 페이지에서 Footer가 1번만 렌더링되는지 확인
- [ ] 로그인 페이지에서 Footer가 표시되지 않는지 확인