### PR TITLE
feat: 메인페이지 이벤트/수상내역 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1428,6 +1429,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
       "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -1528,6 +1530,7 @@
       "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -1538,6 +1541,7 @@
       "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1598,6 +1602,7 @@
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -1850,6 +1855,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2088,6 +2094,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -2519,6 +2526,7 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3751,6 +3759,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3897,6 +3906,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4036,6 +4046,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4045,6 +4056,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -4584,6 +4596,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4643,6 +4656,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4736,6 +4750,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4856,6 +4871,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -1,21 +1,7 @@
 import { client } from '@/api/client';
+import type { Award, MainEvent } from '@/types/Main';
 
-// 타입 정의
-
-export interface MainEvent {
-  id: number;
-  title: string;
-  start: string;
-  end: string;
-  imgUrl: string | null;
-}
-
-export interface Award {
-  tabIdx: number;
-  year: number;
-  type: [number, number, number, number];
-}
-
+// API 함수
 export const getMainEvents = () => {
   return client.get<{ data: MainEvent[] }>('/api/v1/events').then((res) => res.data.data);
 };

--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -1,0 +1,25 @@
+import { client } from '@/api/client';
+
+// 타입 정의
+
+export interface MainEvent {
+  id: number;
+  title: string;
+  start: string;
+  end: string;
+  imgUrl: string | null;
+}
+
+export interface Award {
+  tabIdx: number;
+  year: number;
+  type: [number, number, number, number];
+}
+
+export const getMainEvents = () => {
+  return client.get<{ data: MainEvent[] }>('/api/v1/events').then((res) => res.data.data);
+};
+
+export const getAwards = () => {
+  return client.get<{ data: Award[] }>('/api/v1/awards').then((res) => res.data.data);
+};

--- a/src/components/sections/MainPage/Awards.tsx
+++ b/src/components/sections/MainPage/Awards.tsx
@@ -1,55 +1,10 @@
 import Trophyicon from '@/assets/icon/Trophy.png';
 import PillTab from '@/components/ui/PillTab/PillTab';
 import { useState } from 'react';
+import { useAwards } from '@/hooks/useMain';
 
 export default function Awards() {
-  const awards = [
-    {
-      tabIdx: 0,
-      year: 2019,
-      type: [0, 0, 0, 1],
-    },
-    {
-      tabIdx: 0,
-      year: 2021,
-      type: [0, 1, 0, 1],
-    },
-    {
-      tabIdx: 0,
-      year: 2022,
-      type: [0, 0, 0, 1],
-    },
-    {
-      tabIdx: 0,
-      year: 2023,
-      type: [0, 1, 0, 0],
-    },
-    {
-      tabIdx: 0,
-      year: 2024,
-      type: [0, 0, 1, 0],
-    },
-    {
-      tabIdx: 0,
-      year: 2025,
-      type: [0, 0, 0, 1],
-    },
-    {
-      tabIdx: 1,
-      year: 2019,
-      type: [2, 2, 2, 0],
-    },
-    {
-      tabIdx: 1,
-      year: 2024,
-      type: [2, 2, 4, 0],
-    },
-    {
-      tabIdx: 1,
-      year: 2025,
-      type: [2, 0, 2, 4],
-    },
-  ];
+  const { data } = useAwards();
 
   const [activeTabIdx, setActiveTabIdx] = useState<number>(0);
 
@@ -78,7 +33,7 @@ export default function Awards() {
         />
 
         <div className="grid min-h-[300px] w-full grid-cols-2 gap-2 rounded-lg bg-[#DCDAEF] p-3 md:min-h-[350px] md:grid-cols-3">
-          {awards
+          {(data ?? [])
             .filter((award) => award.tabIdx === activeTabIdx)
             .map((award, index) => (
               <div

--- a/src/components/sections/MainPage/Event.tsx
+++ b/src/components/sections/MainPage/Event.tsx
@@ -7,12 +7,13 @@ import zeroneCharacter from '@/assets/images/zerone_character.png';
 import MT from '@/assets/eventImg/MT.webp';
 import { Autoplay, Navigation, Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
+import { useMainEvents } from '@/hooks/useMain';
 
 interface EventBoxProps {
   title: string;
   start: string;
   end: string;
-  imgUrl?: string;
+  imgUrl?: string | null;
   className?: string;
 }
 
@@ -38,44 +39,7 @@ function EventBox({ title, start, end, imgUrl, className }: EventBoxProps) {
 }
 
 export default function Event() {
-  const events = [
-    {
-      title: '개강총회',
-      start: '2026.03.19',
-      end: '2026.03.19',
-      imgUrl: '',
-    },
-    {
-      title: 'MT',
-      start: '2026.05.29',
-      end: '2026.05.30',
-      imgUrl: MT,
-    },
-    {
-      title: '1&N 네트워킹데이',
-      start: '2026.05.09',
-      end: '2026.05.09',
-      imgUrl: oneAndN,
-    },
-    {
-      title: '스터디',
-      start: '2026.03.23',
-      end: '2026.06.05',
-      imgUrl: study,
-    },
-    {
-      title: '백준마라톤',
-      start: '2026.03.23',
-      end: '2026.06.05',
-      imgUrl: marathon,
-    },
-    {
-      title: '모.각.코',
-      start: '2026.03.23',
-      end: '2026.06.19',
-      imgUrl: mogakco,
-    },
-  ];
+  const { data } = useMainEvents();
 
   return (
     <div
@@ -96,7 +60,7 @@ export default function Event() {
             autoplay={{ delay: 9000, disableOnInteraction: false }}
             className="w-full"
           >
-            {events.map((event, index) => (
+            {(data ?? []).map((event, index) => (
               <SwiperSlide key={index}>
                 <EventBox
                   title={event.title}
@@ -114,7 +78,7 @@ export default function Event() {
         {' '}
         {/* 컴퓨터 화면 */}
         <div className="grid grid-cols-3 gap-4">
-          {events.map((event, index) => (
+          {(data ?? []).map((event, index) => (
             <EventBox
               key={index}
               title={event.title}

--- a/src/components/sections/MainPage/Event.tsx
+++ b/src/components/sections/MainPage/Event.tsx
@@ -1,10 +1,5 @@
-import oneAndN from '@/assets/eventImg/1&N.png';
-import mogakco from '@/assets/eventImg/mogakco.webp';
-import marathon from '@/assets/eventImg/marathon.webp';
-import study from '@/assets/eventImg/study.webp';
 import clockIcon from '@/assets/icon/clock.png';
 import zeroneCharacter from '@/assets/images/zerone_character.png';
-import MT from '@/assets/eventImg/MT.webp';
 import { Autoplay, Navigation, Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { useMainEvents } from '@/hooks/useMain';

--- a/src/hooks/useMain.ts
+++ b/src/hooks/useMain.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { getMainEvents, getAwards } from '@/api/main';
+
+export const useMainEvents = () => {
+  return useQuery({
+    queryKey: ['mainEvents'],
+    queryFn: getMainEvents,
+  });
+};
+
+export const useAwards = () => {
+  return useQuery({
+    queryKey: ['awards'],
+    queryFn: getAwards,
+  });
+};

--- a/src/types/Main.ts
+++ b/src/types/Main.ts
@@ -1,0 +1,15 @@
+// 타입 정의
+
+export interface MainEvent {
+  id: number;
+  title: string;
+  start: string;
+  end: string;
+  imgUrl: string | null;
+}
+
+export interface Award {
+  tabIdx: number;
+  year: number;
+  type: [number, number, number, number];
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,4 +29,13 @@ RewriteRule ^ index.html [QSA,L]`;
       '@': path.resolve(__dirname, './src'),
     },
   },
+  server: {
+  proxy: {
+    '/api': {
+      target: 'http://zerone01.kr',
+      changeOrigin: true,
+    },
+  },
+},
+  
 });


### PR DESCRIPTION
## 작업 내용
- GET /events 이벤트 목록 API 연동
- GET /awards 수상내역 API 연동

## 변경 파일
- `api/main.ts`, `hooks/useMain.ts`, `types/Main.ts` 추가
- `Event.tsx`, `Awards.tsx`  → API 호출로 교체